### PR TITLE
Fix release in gradle 9.3.1

### DIFF
--- a/release-commons.gradle
+++ b/release-commons.gradle
@@ -16,6 +16,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
@@ -45,28 +46,28 @@ javadoc {
 
 assemble.dependsOn sourcesJar, javadocJar
 
-def pomConfig = {
-    url = "https://github.com/reportportal/${project.name}"
-    packaging = 'jar'
-    licenses {
-        license {
-            name = "The Apache Software License, Version 2.0"
-            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            distribution = "repo"
+def configurePom = { pom ->
+    pom.url = "https://github.com/reportportal/${project.name}"
+    pom.packaging = 'jar'
+    pom.licenses { licenses ->
+        licenses.license { license ->
+            license.name = "The Apache Software License, Version 2.0"
+            license.url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            license.distribution = "repo"
         }
     }
-    developers {
-        developer {
-            name = 'EPAM Systems'
-            email = 'support@reportportal.io'
-            organization = 'ReportPortal.io'
-            organizationUrl = 'http://www.reportportal.io'
+    pom.developers { developers ->
+        developers.developer { developer ->
+            developer.name = 'EPAM Systems'
+            developer.email = 'support@reportportal.io'
+            developer.organization = 'ReportPortal.io'
+            developer.organizationUrl = 'http://www.reportportal.io'
         }
     }
-    scm {
-        connection = "scm:git:https://github.com/reportportal/${project.name}.git"
-        developerConnection = "scm:git:ssh://git@github.com:reportportal/${project.name}.git"
-        url = "https://github.com/reportportal/${project.name}/tree/master"
+    pom.scm { scm ->
+        scm.connection = "scm:git:https://github.com/reportportal/${project.name}.git"
+        scm.developerConnection = "scm:git:ssh://git@github.com:reportportal/${project.name}.git"
+        scm.url = "https://github.com/reportportal/${project.name}/tree/master"
     }
 }
 
@@ -92,14 +93,10 @@ publishing {
             groupId = 'com.epam.reportportal'
             artifactId = "$project.name"
 
-            pom {
-                name = "${project.name}"
-                description = "${project.description}"
-            }
-
-            pom.withXml {
-                def root = asNode()
-                root.children().last() + pomConfig
+            pom { pom ->
+                pom.name = "${project.name}"
+                pom.description = "${project.description}"
+                configurePom(pom)
             }
             artifact sourcesJar
             artifact javadocJar

--- a/release-fat.gradle
+++ b/release-fat.gradle
@@ -69,6 +69,10 @@ def configurePom = { pom ->
     }
 }
 
+tasks.named('shadowJar') {
+    archiveClassifier.set('')
+}
+
 assemble.dependsOn sourcesJar, javadocJar, shadowJar
 
 project.ext.githubUserName = project.hasProperty('githubUserName') ? githubUserName : ""
@@ -89,9 +93,12 @@ publishing {
 
     publications {
         shadow(MavenPublication) { publication ->
-            from components.java
-            
-            artifacts = [project.tasks.shadowJar, project.tasks.javadocJar, project.tasks.sourcesJar]
+            artifact project.tasks.shadowJar
+            artifact project.tasks.javadocJar
+            artifact project.tasks.sourcesJar
+
+            groupId = 'com.epam.reportportal'
+            artifactId = "$project.name"
 
             pom { pom ->
                 pom.name = "${project.name}"
@@ -101,17 +108,18 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
-                root.dependencies.'*'.findAll() {
-                    it.scope.text() == 'runtime' && project.configurations.shadow.allDependencies.find { dep ->
-                        dep.name == it.artifactId.text()
+                
+                def dependenciesNode = root.appendNode('dependencies')
+                project.configurations.runtimeClasspath.allDependencies.each { dep ->
+                    if (dep.group != null && dep.name != null && dep.version != null) {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', dep.group)
+                        dependencyNode.appendNode('artifactId', dep.name)
+                        dependencyNode.appendNode('version', dep.version)
+                        dependencyNode.appendNode('scope', 'compile')
                     }
-                }.each() {
-                    it.scope*.value = 'compile'
                 }
             }
-
-            groupId = 'com.epam.reportportal'
-            artifactId = "$project.name"
 
         }
     }

--- a/release-fat.gradle
+++ b/release-fat.gradle
@@ -89,8 +89,9 @@ publishing {
 
     publications {
         shadow(MavenPublication) { publication ->
-            from components.shadow
+            project.shadow.component(publication)
 
+            artifact project.tasks.shadowJar
             artifact project.tasks.javadocJar
             artifact project.tasks.sourcesJar
 

--- a/release-fat.gradle
+++ b/release-fat.gradle
@@ -69,6 +69,7 @@ def configurePom = { pom ->
     }
 }
 
+// Configure shadowJar to have no classifier (produces plugin-name-version.jar)
 tasks.named('shadowJar') {
     archiveClassifier.set('')
 }
@@ -93,7 +94,7 @@ publishing {
 
     publications {
         shadow(MavenPublication) { publication ->
-            artifact project.tasks.shadowJar
+            from components.shadow
             artifact project.tasks.javadocJar
             artifact project.tasks.sourcesJar
 
@@ -105,22 +106,6 @@ publishing {
                 pom.description = "${project.description}"
                 configurePom(pom)
             }
-
-            pom.withXml {
-                def root = asNode()
-                
-                def dependenciesNode = root.appendNode('dependencies')
-                project.configurations.runtimeClasspath.allDependencies.each { dep ->
-                    if (dep.group != null && dep.name != null && dep.version != null) {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', dep.group)
-                        dependencyNode.appendNode('artifactId', dep.name)
-                        dependencyNode.appendNode('version', dep.version)
-                        dependencyNode.appendNode('scope', 'compile')
-                    }
-                }
-            }
-
         }
     }
 }

--- a/release-fat.gradle
+++ b/release-fat.gradle
@@ -16,6 +16,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
@@ -43,28 +44,28 @@ javadoc {
     failOnError = false
 }
 
-def pomConfig = {
-    url = "https://github.com/reportportal/${project.name}"
-    packaging = 'jar'
-    licenses {
-        license {
-            name = "The Apache Software License, Version 2.0"
-            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            distribution = "repo"
+def configurePom = { pom ->
+    pom.url = "https://github.com/reportportal/${project.name}"
+    pom.packaging = 'jar'
+    pom.licenses { licenses ->
+        licenses.license { license ->
+            license.name = "The Apache Software License, Version 2.0"
+            license.url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            license.distribution = "repo"
         }
     }
-    developers {
-        developer {
-            name = 'EPAM Systems'
-            email = 'support@reportportal.io'
-            organization = 'ReportPortal.io'
-            organizationUrl = 'http://www.reportportal.io'
+    pom.developers { developers ->
+        developers.developer { developer ->
+            developer.name = 'EPAM Systems'
+            developer.email = 'support@reportportal.io'
+            developer.organization = 'ReportPortal.io'
+            developer.organizationUrl = 'http://www.reportportal.io'
         }
     }
-    scm {
-        connection = "scm:git:https://github.com/reportportal/${project.name}.git"
-        developerConnection = "scm:git:ssh://git@github.com:reportportal/${project.name}.git"
-        url = "https://github.com/reportportal/${project.name}/tree/master"
+    pom.scm { scm ->
+        scm.connection = "scm:git:https://github.com/reportportal/${project.name}.git"
+        scm.developerConnection = "scm:git:ssh://git@github.com:reportportal/${project.name}.git"
+        scm.url = "https://github.com/reportportal/${project.name}/tree/master"
     }
 }
 
@@ -93,9 +94,10 @@ publishing {
             artifact project.tasks.javadocJar
             artifact project.tasks.sourcesJar
 
-            pom {
-                name = "${project.name}"
-                description = "${project.description}"
+            pom { pom ->
+                pom.name = "${project.name}"
+                pom.description = "${project.description}"
+                configurePom(pom)
             }
 
             pom.withXml {
@@ -107,7 +109,6 @@ publishing {
                 }.each() {
                     it.scope*.value = 'compile'
                 }
-                root.children().last() + pomConfig
             }
 
             groupId = 'com.epam.reportportal'

--- a/release-fat.gradle
+++ b/release-fat.gradle
@@ -74,6 +74,11 @@ tasks.named('shadowJar') {
     archiveClassifier.set('')
 }
 
+// Disable the regular jar task to avoid conflict with shadowJar
+tasks.named('jar') {
+    enabled = false
+}
+
 assemble.dependsOn sourcesJar, javadocJar, shadowJar
 
 project.ext.githubUserName = project.hasProperty('githubUserName') ? githubUserName : ""

--- a/release-fat.gradle
+++ b/release-fat.gradle
@@ -89,11 +89,9 @@ publishing {
 
     publications {
         shadow(MavenPublication) { publication ->
-            project.shadow.component(publication)
-
-            artifact project.tasks.shadowJar
-            artifact project.tasks.javadocJar
-            artifact project.tasks.sourcesJar
+            from components.java
+            
+            artifacts = [project.tasks.shadowJar, project.tasks.javadocJar, project.tasks.sourcesJar]
 
             pom { pom ->
                 pom.name = "${project.name}"

--- a/release-service.gradle
+++ b/release-service.gradle
@@ -15,6 +15,7 @@
  */
 buildscript {
     repositories {
+        mavenCentral()
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
@@ -46,28 +47,28 @@ tasks.named('assemble') {
     dependsOn(sourcesJar, javadocJar)
 }
 
-def pomConfig = {
-    url = "https://github.com/reportportal/${project.name}"
-    packaging = 'jar'
-    licenses {
-        license {
-            name = "The Apache Software License, Version 2.0"
-            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            distribution = "repo"
+def configurePom = { pom ->
+    pom.url = "https://github.com/reportportal/${project.name}"
+    pom.packaging = 'jar'
+    pom.licenses { licenses ->
+        licenses.license { license ->
+            license.name = "The Apache Software License, Version 2.0"
+            license.url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            license.distribution = "repo"
         }
     }
-    developers {
-        developer {
-            name = 'EPAM Systems'
-            email = 'support@reportportal.io'
-            organization = 'ReportPortal.io'
-            organizationUrl = 'http://www.reportportal.io'
+    pom.developers { developers ->
+        developers.developer { developer ->
+            developer.name = 'EPAM Systems'
+            developer.email = 'support@reportportal.io'
+            developer.organization = 'ReportPortal.io'
+            developer.organizationUrl = 'http://www.reportportal.io'
         }
     }
-    scm {
-        connection = "scm:git:https://github.com/reportportal/${project.name}.git"
-        developerConnection = "scm:git:ssh://git@github.com:reportportal/${project.name}.git"
-        url = "https://github.com/reportportal/${project.name}/tree/master"
+    pom.scm { scm ->
+        scm.connection = "scm:git:https://github.com/reportportal/${project.name}.git"
+        scm.developerConnection = "scm:git:ssh://git@github.com:reportportal/${project.name}.git"
+        scm.url = "https://github.com/reportportal/${project.name}/tree/master"
     }
 }
 
@@ -97,12 +98,11 @@ publishing {
             groupId = 'com.epam.reportportal'
             artifactId = "$project.name"
 
-            pom {
-                name = "${project.name}"
-                description = "${project.description}"
+            pom { pom ->
+                pom.name = "${project.name}"
+                pom.description = "${project.description}"
+                configurePom(pom)
             }
-
-            pom pomConfig
 
             artifact sourcesJar
             artifact javadocJar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized and parameterized POM metadata across build scripts for consistent published artifact info.
  * Standardized publishing DSL and added mavenCentral to build repositories for consistency.

* **New Features**
  * Publications now include explicit artifacts (including fat/shaded artifact) and repository configuration with credential properties to simplify releases.
  * Published POMs now generate clearer dependency information for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->